### PR TITLE
Add github action to release

### DIFF
--- a/.github/workflows/flutter-multi-platform-build.yml
+++ b/.github/workflows/flutter-multi-platform-build.yml
@@ -7,8 +7,8 @@ env:
   FLUTTER_VERSION: "3.35.5"
 
 jobs:
-  linux_android_web:
-    name: Linux • Android • Web
+  linux:
+    name: Linux Desktop
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -31,38 +31,16 @@ jobs:
             libgtk-3-dev \
             liblzma-dev
 
-      - name: Configure Flutter targets
+      - name: Configure Flutter
         run: |
           flutter config --no-analytics
           flutter config --enable-linux-desktop
-          flutter config --enable-web
-          flutter doctor
 
       - name: Fetch Dart dependencies
         run: flutter pub get
 
-      - name: Accept Android licenses
-        run: |
-          yes | "${ANDROID_SDK_ROOT:-$ANDROID_HOME}"/cmdline-tools/latest/bin/sdkmanager --licenses
-
-      - name: Build Web (release)
-        run: flutter build web --release
-
       - name: Build Linux desktop (release)
         run: flutter build linux --release
-
-      - name: Build Android App Bundle (release)
-        run: flutter build appbundle --release
-
-      - name: Build Android APKs (release)
-        run: flutter build apk --split-per-abi --release
-
-      - name: Upload Web artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: web-release
-          path: build/web
-          if-no-files-found: error
 
       - name: Upload Linux artifact
         uses: actions/upload-artifact@v4
@@ -70,6 +48,31 @@ jobs:
           name: linux-release
           path: build/linux/x64/release/bundle
           if-no-files-found: error
+
+  android:
+    name: Android
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Flutter ${{ env.FLUTTER_VERSION }}
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: stable
+
+      - name: Configure Flutter
+        run: flutter config --no-analytics
+
+      - name: Fetch Dart dependencies
+        run: flutter pub get
+
+      - name: Build Android App Bundle (release)
+        run: flutter build appbundle --release
+
+      - name: Build Android APKs (release)
+        run: flutter build apk --split-per-abi --release
 
       - name: Upload Android artifacts
         uses: actions/upload-artifact@v4
@@ -80,8 +83,39 @@ jobs:
             build/app/outputs/**/*.apk
           if-no-files-found: error
 
-  macos_ios:
-    name: macOS • iOS
+  web:
+    name: Web
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Flutter ${{ env.FLUTTER_VERSION }}
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: stable
+
+      - name: Configure Flutter
+        run: |
+          flutter config --no-analytics
+          flutter config --enable-web
+
+      - name: Fetch Dart dependencies
+        run: flutter pub get
+
+      - name: Build Web (release)
+        run: flutter build web --release
+
+      - name: Upload Web artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: web-release
+          path: build/web
+          if-no-files-found: error
+
+  macos:
+    name: macOS Desktop
     runs-on: macos-latest
     steps:
       - name: Checkout repository
@@ -93,19 +127,10 @@ jobs:
           flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: stable
 
-      - name: Prepare macOS toolchain
+      - name: Configure Flutter
         run: |
           flutter config --no-analytics
           flutter config --enable-macos-desktop
-          flutter config --enable-ios
-          sudo xcode-select --switch /Applications/Xcode.app
-          sudo xcodebuild -license accept
-
-      - name: Install CocoaPods
-        run: |
-          brew install cocoapods || true
-          cd ios
-          pod install
 
       - name: Fetch Dart dependencies
         run: flutter pub get
@@ -113,15 +138,41 @@ jobs:
       - name: Build macOS desktop (release)
         run: flutter build macos --release
 
-      - name: Build iOS IPA (release, no codesign)
-        run: flutter build ipa --release --no-codesign
-
       - name: Upload macOS artifact
         uses: actions/upload-artifact@v4
         with:
           name: macos-release
           path: build/macos/Build/Products/Release
           if-no-files-found: error
+
+  ios:
+    name: iOS
+    runs-on: macos-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Flutter ${{ env.FLUTTER_VERSION }}
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: stable
+
+      - name: Configure Flutter
+        run: |
+          flutter config --no-analytics
+          flutter config --enable-ios
+
+      - name: Fetch Dart dependencies
+        run: flutter pub get
+
+      - name: Install CocoaPods dependencies
+        run: |
+          cd ios
+          pod install
+
+      - name: Build iOS IPA (release, no codesign)
+        run: flutter build ipa --release --no-codesign
 
       - name: Upload iOS artifact
         uses: actions/upload-artifact@v4
@@ -143,16 +194,6 @@ jobs:
           flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: stable
 
-      - name: Ensure Windows build toolchain
-        shell: pwsh
-        run: |
-          if (-not (Get-Command ninja -ErrorAction SilentlyContinue)) {
-            choco install ninja -y --no-progress
-          }
-          if (-not (Get-Command cmake -ErrorAction SilentlyContinue)) {
-            choco install cmake -y --installargs 'ADD_CMAKE_TO_PATH=System' --no-progress
-          }
-
       - name: Configure Flutter target
         shell: pwsh
         run: |
@@ -173,3 +214,115 @@ jobs:
           name: windows-release
           path: build/windows/x64/runner/Release
           if-no-files-found: error
+
+  create_release:
+    name: Create Release Draft
+    runs-on: ubuntu-latest
+    needs: [linux, android, web, macos, ios, windows]
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Get version from pubspec.yaml
+        id: get_version
+        run: |
+          VERSION=$(grep '^version:' pubspec.yaml | sed 's/version: //' | sed 's/+.*//')
+          BUILD_NUMBER=$(grep '^version:' pubspec.yaml | sed 's/.*+//')
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "build_number=$BUILD_NUMBER" >> $GITHUB_OUTPUT
+          echo "Version: $VERSION"
+          echo "Build Number: $BUILD_NUMBER"
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Package all builds
+        run: |
+          VERSION="${{ steps.get_version.outputs.version }}"
+          
+          # Package Linux
+          cd artifacts/linux-release
+          tar -czf "../../rust_assistant-v${VERSION}-linux-x64.tar.gz" *
+          cd ../..
+          
+          # Package macOS
+          cd artifacts/macos-release
+          zip -r "../../rust_assistant-v${VERSION}-macos.zip" *
+          cd ../..
+          
+          # Package Windows
+          cd artifacts/windows-release
+          zip -r "../../rust_assistant-v${VERSION}-windows-x64.zip" *
+          cd ../..
+          
+          # Package Web
+          cd artifacts/web-release
+          zip -r "../../rust_assistant-v${VERSION}-web.zip" *
+          cd ../..
+          
+          # Rename Android artifacts
+          mkdir -p android-packaged
+          find artifacts/android-release -name "*.aab" -exec cp {} "android-packaged/rust_assistant-v${VERSION}.aab" \;
+          find artifacts/android-release -name "*arm64-v8a*.apk" -exec cp {} "android-packaged/rust_assistant-v${VERSION}-arm64-v8a.apk" \;
+          find artifacts/android-release -name "*armeabi-v7a*.apk" -exec cp {} "android-packaged/rust_assistant-v${VERSION}-armeabi-v7a.apk" \;
+          find artifacts/android-release -name "*x86_64*.apk" -exec cp {} "android-packaged/rust_assistant-v${VERSION}-x86_64.apk" \;
+          
+          # Package iOS
+          cd artifacts/ios-ipa
+          zip -r "../../rust_assistant-v${VERSION}-ios-unsigned.zip" *
+          cd ../..
+
+      - name: Create Release Draft
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ steps.get_version.outputs.version }}
+          name: Rust Assistant v${{ steps.get_version.outputs.version }}
+          draft: true
+          prerelease: false
+          body: |
+            ## Rust Assistant v${{ steps.get_version.outputs.version }}
+            
+            **构建信息**
+            - 版本号: `${{ steps.get_version.outputs.version }}`
+            - 内部版本号: `${{ steps.get_version.outputs.build_number }}`
+            - 构建编号: `${{ github.run_number }}`
+            - 提交哈希: `${{ github.sha }}`
+            - 构建时间: `${{ github.event.repository.updated_at }}`
+            
+            ### 📦 下载说明
+            
+            #### 桌面平台
+            - **Linux**: `rust_assistant-v${{ steps.get_version.outputs.version }}-linux-x64.tar.gz` - 解压后运行 `rust_assistant`
+            - **macOS**: `rust_assistant-v${{ steps.get_version.outputs.version }}-macos.zip` - 解压后运行 `rust_assistant.app`
+            - **Windows**: `rust_assistant-v${{ steps.get_version.outputs.version }}-windows-x64.zip` - 解压后运行 `rust_assistant.exe`
+            
+            #### 移动平台
+            - **Android AAB**: `rust_assistant-v${{ steps.get_version.outputs.version }}.aab` - 用于上传到 Google Play（需重新签名）
+            - **Android APK (ARM64)**: `rust_assistant-v${{ steps.get_version.outputs.version }}-arm64-v8a.apk` - 适用于现代 64 位 Android 设备
+            - **Android APK (ARMv7)**: `rust_assistant-v${{ steps.get_version.outputs.version }}-armeabi-v7a.apk` - 适用于老旧 32 位 Android 设备
+            - **Android APK (x86_64)**: `rust_assistant-v${{ steps.get_version.outputs.version }}-x86_64.apk` - 适用于模拟器或 x86 设备
+            - **iOS**: `rust_assistant-v${{ steps.get_version.outputs.version }}-ios-unsigned.zip` - 未签名，需要重新签名后才能安装
+            
+            #### Web 平台
+            - **Web**: `rust_assistant-v${{ steps.get_version.outputs.version }}-web.zip` - 解压后部署到 Web 服务器
+            
+            ### ⚠️ 注意事项
+            
+            - **Android**: 使用 debug 签名，可直接安装测试，但无法上传到 Play Store
+            - **iOS**: 未签名，需要使用 Xcode 或其他工具重新签名
+            - **macOS**: 未签名，首次运行时需要右键选择"打开"绕过安全检查
+            - **Windows**: 未签名，SmartScreen 可能会显示警告
+          files: |
+            rust_assistant-v${{ steps.get_version.outputs.version }}-linux-x64.tar.gz
+            rust_assistant-v${{ steps.get_version.outputs.version }}-macos.zip
+            rust_assistant-v${{ steps.get_version.outputs.version }}-windows-x64.zip
+            rust_assistant-v${{ steps.get_version.outputs.version }}-web.zip
+            android-packaged/rust_assistant-v${{ steps.get_version.outputs.version }}.aab
+            android-packaged/rust_assistant-v${{ steps.get_version.outputs.version }}-arm64-v8a.apk
+            android-packaged/rust_assistant-v${{ steps.get_version.outputs.version }}-armeabi-v7a.apk
+            android-packaged/rust_assistant-v${{ steps.get_version.outputs.version }}-x86_64.apk
+            rust_assistant-v${{ steps.get_version.outputs.version }}-ios-unsigned.zip

--- a/.github/workflows/flutter-multi-platform-build.yml
+++ b/.github/workflows/flutter-multi-platform-build.yml
@@ -83,7 +83,6 @@ jobs:
   macos_ios:
     name: macOS • iOS
     runs-on: macos-latest
-    needs: linux_android_web
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -134,7 +133,6 @@ jobs:
   windows:
     name: Windows
     runs-on: windows-latest
-    needs: linux_android_web
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/flutter-multi-platform-build.yml
+++ b/.github/workflows/flutter-multi-platform-build.yml
@@ -171,14 +171,19 @@ jobs:
           cd ios
           pod install
 
-      - name: Build iOS IPA (release, no codesign)
-        run: flutter build ipa --release --no-codesign
+      - name: Build iOS (release, no codesign)
+        run: flutter build ios --release --no-codesign
+
+      - name: Create iOS App directory
+        run: |
+          mkdir -p build/ios/iphoneos-unsigned
+          cp -r build/ios/iphoneos/Runner.app build/ios/iphoneos-unsigned/
 
       - name: Upload iOS artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ios-ipa
-          path: build/ios/ipa
+          name: ios-app
+          path: build/ios/iphoneos-unsigned
           if-no-files-found: error
 
   windows:
@@ -272,7 +277,7 @@ jobs:
           find artifacts/android-release -name "*x86_64*.apk" -exec cp {} "android-packaged/rust_assistant-v${VERSION}-x86_64.apk" \;
           
           # Package iOS
-          cd artifacts/ios-ipa
+          cd artifacts/ios-app
           zip -r "../../rust_assistant-v${VERSION}-ios-unsigned.zip" *
           cd ../..
 
@@ -305,7 +310,7 @@ jobs:
             - **Android APK (ARM64)**: `rust_assistant-v${{ steps.get_version.outputs.version }}-arm64-v8a.apk` - 适用于现代 64 位 Android 设备
             - **Android APK (ARMv7)**: `rust_assistant-v${{ steps.get_version.outputs.version }}-armeabi-v7a.apk` - 适用于老旧 32 位 Android 设备
             - **Android APK (x86_64)**: `rust_assistant-v${{ steps.get_version.outputs.version }}-x86_64.apk` - 适用于模拟器或 x86 设备
-            - **iOS**: `rust_assistant-v${{ steps.get_version.outputs.version }}-ios-unsigned.zip` - 未签名，需要重新签名后才能安装
+            - **iOS**: `rust_assistant-v${{ steps.get_version.outputs.version }}-ios-unsigned.zip` - 未签名的 Runner.app，需使用 Xcode 或签名工具处理后安装
             
             #### Web 平台
             - **Web**: `rust_assistant-v${{ steps.get_version.outputs.version }}-web.zip` - 解压后部署到 Web 服务器
@@ -313,7 +318,7 @@ jobs:
             ### ⚠️ 注意事项
             
             - **Android**: 使用 debug 签名，可直接安装测试，但无法上传到 Play Store
-            - **iOS**: 未签名，需要使用 Xcode 或其他工具重新签名
+            - **iOS**: 包含未签名的 Runner.app，需要使用 Xcode 重新签名或使用 `codesign` 工具签名后才能安装到设备
             - **macOS**: 未签名，首次运行时需要右键选择"打开"绕过安全检查
             - **Windows**: 未签名，SmartScreen 可能会显示警告
           files: |

--- a/.github/workflows/flutter-multi-platform-build.yml
+++ b/.github/workflows/flutter-multi-platform-build.yml
@@ -68,9 +68,6 @@ jobs:
       - name: Fetch Dart dependencies
         run: flutter pub get
 
-      - name: Build Android App Bundle (release)
-        run: flutter build appbundle --release
-
       - name: Build Android APKs (release)
         run: flutter build apk --split-per-abi --release
 
@@ -78,9 +75,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: android-release
-          path: |
-            build/app/outputs/**/*.aab
-            build/app/outputs/**/*.apk
+          path: build/app/outputs/flutter-apk/*.apk
           if-no-files-found: error
 
   web:
@@ -269,12 +264,11 @@ jobs:
           zip -r "../../rust_assistant-v${VERSION}-web.zip" *
           cd ../..
           
-          # Rename Android artifacts
+          # Rename Android APK artifacts
           mkdir -p android-packaged
-          find artifacts/android-release -name "*.aab" -exec cp {} "android-packaged/rust_assistant-v${VERSION}.aab" \;
-          find artifacts/android-release -name "*arm64-v8a*.apk" -exec cp {} "android-packaged/rust_assistant-v${VERSION}-arm64-v8a.apk" \;
-          find artifacts/android-release -name "*armeabi-v7a*.apk" -exec cp {} "android-packaged/rust_assistant-v${VERSION}-armeabi-v7a.apk" \;
-          find artifacts/android-release -name "*x86_64*.apk" -exec cp {} "android-packaged/rust_assistant-v${VERSION}-x86_64.apk" \;
+          find artifacts/android-release -name "*arm64-v8a-release.apk" -exec cp {} "android-packaged/rust_assistant-v${VERSION}-arm64-v8a.apk" \;
+          find artifacts/android-release -name "*armeabi-v7a-release.apk" -exec cp {} "android-packaged/rust_assistant-v${VERSION}-armeabi-v7a.apk" \;
+          find artifacts/android-release -name "*x86_64-release.apk" -exec cp {} "android-packaged/rust_assistant-v${VERSION}-x86_64.apk" \;
           
           # Package iOS
           cd artifacts/ios-app
@@ -306,10 +300,9 @@ jobs:
             - **Windows**: `rust_assistant-v${{ steps.get_version.outputs.version }}-windows-x64.zip` - 解压后运行 `rust_assistant.exe`
             
             #### 移动平台
-            - **Android AAB**: `rust_assistant-v${{ steps.get_version.outputs.version }}.aab` - 用于上传到 Google Play（需重新签名）
-            - **Android APK (ARM64)**: `rust_assistant-v${{ steps.get_version.outputs.version }}-arm64-v8a.apk` - 适用于现代 64 位 Android 设备
+            - **Android APK (ARM64)**: `rust_assistant-v${{ steps.get_version.outputs.version }}-arm64-v8a.apk` - 推荐，适用于现代 64 位 Android 设备（大部分设备）
             - **Android APK (ARMv7)**: `rust_assistant-v${{ steps.get_version.outputs.version }}-armeabi-v7a.apk` - 适用于老旧 32 位 Android 设备
-            - **Android APK (x86_64)**: `rust_assistant-v${{ steps.get_version.outputs.version }}-x86_64.apk` - 适用于模拟器或 x86 设备
+            - **Android APK (x86_64)**: `rust_assistant-v${{ steps.get_version.outputs.version }}-x86_64.apk` - 适用于 Android 模拟器或 x86 架构设备
             - **iOS**: `rust_assistant-v${{ steps.get_version.outputs.version }}-ios-unsigned.zip` - 未签名的 Runner.app，需使用 Xcode 或签名工具处理后安装
             
             #### Web 平台
@@ -317,7 +310,7 @@ jobs:
             
             ### ⚠️ 注意事项
             
-            - **Android**: 使用 debug 签名，可直接安装测试，但无法上传到 Play Store
+            - **Android**: 使用 debug 签名，可直接下载安装到设备（需允许安装未知来源应用）
             - **iOS**: 包含未签名的 Runner.app，需要使用 Xcode 重新签名或使用 `codesign` 工具签名后才能安装到设备
             - **macOS**: 未签名，首次运行时需要右键选择"打开"绕过安全检查
             - **Windows**: 未签名，SmartScreen 可能会显示警告
@@ -326,7 +319,6 @@ jobs:
             rust_assistant-v${{ steps.get_version.outputs.version }}-macos.zip
             rust_assistant-v${{ steps.get_version.outputs.version }}-windows-x64.zip
             rust_assistant-v${{ steps.get_version.outputs.version }}-web.zip
-            android-packaged/rust_assistant-v${{ steps.get_version.outputs.version }}.aab
             android-packaged/rust_assistant-v${{ steps.get_version.outputs.version }}-arm64-v8a.apk
             android-packaged/rust_assistant-v${{ steps.get_version.outputs.version }}-armeabi-v7a.apk
             android-packaged/rust_assistant-v${{ steps.get_version.outputs.version }}-x86_64.apk

--- a/.github/workflows/flutter-multi-platform-build.yml
+++ b/.github/workflows/flutter-multi-platform-build.yml
@@ -137,7 +137,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: macos-release
-          path: build/macos/Build/Products/Release
+          path: build/macos/Build/Products/Release/*.app
           if-no-files-found: error
 
   ios:

--- a/.github/workflows/flutter-multi-platform-build.yml
+++ b/.github/workflows/flutter-multi-platform-build.yml
@@ -1,0 +1,177 @@
+name: Flutter Multi-Platform Build
+
+on:
+  workflow_dispatch:
+
+env:
+  FLUTTER_VERSION: "3.35.5"
+
+jobs:
+  linux_android_web:
+    name: Linux • Android • Web
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Flutter ${{ env.FLUTTER_VERSION }}
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: stable
+
+      - name: Install Linux dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends -y \
+            clang \
+            cmake \
+            ninja-build \
+            pkg-config \
+            libgtk-3-dev \
+            liblzma-dev
+
+      - name: Configure Flutter targets
+        run: |
+          flutter config --no-analytics
+          flutter config --enable-linux-desktop
+          flutter config --enable-web
+          flutter doctor
+
+      - name: Fetch Dart dependencies
+        run: flutter pub get
+
+      - name: Accept Android licenses
+        run: |
+          yes | "${ANDROID_SDK_ROOT:-$ANDROID_HOME}"/cmdline-tools/latest/bin/sdkmanager --licenses
+
+      - name: Build Web (release)
+        run: flutter build web --release
+
+      - name: Build Linux desktop (release)
+        run: flutter build linux --release
+
+      - name: Build Android App Bundle (release)
+        run: flutter build appbundle --release
+
+      - name: Build Android APKs (release)
+        run: flutter build apk --split-per-abi --release
+
+      - name: Upload Web artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: web-release
+          path: build/web
+          if-no-files-found: error
+
+      - name: Upload Linux artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-release
+          path: build/linux/x64/release/bundle
+          if-no-files-found: error
+
+      - name: Upload Android artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-release
+          path: |
+            build/app/outputs/**/*.aab
+            build/app/outputs/**/*.apk
+          if-no-files-found: error
+
+  macos_ios:
+    name: macOS • iOS
+    runs-on: macos-latest
+    needs: linux_android_web
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Flutter ${{ env.FLUTTER_VERSION }}
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: stable
+
+      - name: Prepare macOS toolchain
+        run: |
+          flutter config --no-analytics
+          flutter config --enable-macos-desktop
+          flutter config --enable-ios
+          sudo xcode-select --switch /Applications/Xcode.app
+          sudo xcodebuild -license accept
+
+      - name: Install CocoaPods
+        run: |
+          brew install cocoapods || true
+          cd ios
+          pod install
+
+      - name: Fetch Dart dependencies
+        run: flutter pub get
+
+      - name: Build macOS desktop (release)
+        run: flutter build macos --release
+
+      - name: Build iOS IPA (release, no codesign)
+        run: flutter build ipa --release --no-codesign
+
+      - name: Upload macOS artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-release
+          path: build/macos/Build/Products/Release
+          if-no-files-found: error
+
+      - name: Upload iOS artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-ipa
+          path: build/ios/ipa
+          if-no-files-found: error
+
+  windows:
+    name: Windows
+    runs-on: windows-latest
+    needs: linux_android_web
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Flutter ${{ env.FLUTTER_VERSION }}
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: stable
+
+      - name: Ensure Windows build toolchain
+        shell: pwsh
+        run: |
+          if (-not (Get-Command ninja -ErrorAction SilentlyContinue)) {
+            choco install ninja -y --no-progress
+          }
+          if (-not (Get-Command cmake -ErrorAction SilentlyContinue)) {
+            choco install cmake -y --installargs 'ADD_CMAKE_TO_PATH=System' --no-progress
+          }
+
+      - name: Configure Flutter target
+        shell: pwsh
+        run: |
+          flutter config --no-analytics
+          flutter config --enable-windows-desktop
+
+      - name: Fetch Dart dependencies
+        shell: pwsh
+        run: flutter pub get
+
+      - name: Build Windows desktop (release)
+        shell: pwsh
+        run: flutter build windows --release
+
+      - name: Upload Windows artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-release
+          path: build/windows/x64/runner/Release
+          if-no-files-found: error

--- a/.github/workflows/flutter-multi-platform-build.yml
+++ b/.github/workflows/flutter-multi-platform-build.yml
@@ -32,9 +32,7 @@ jobs:
             liblzma-dev
 
       - name: Configure Flutter
-        run: |
-          flutter config --no-analytics
-          flutter config --enable-linux-desktop
+        run: flutter config --no-analytics
 
       - name: Fetch Dart dependencies
         run: flutter pub get
@@ -92,9 +90,7 @@ jobs:
           channel: stable
 
       - name: Configure Flutter
-        run: |
-          flutter config --no-analytics
-          flutter config --enable-web
+        run: flutter config --no-analytics
 
       - name: Fetch Dart dependencies
         run: flutter pub get
@@ -123,9 +119,7 @@ jobs:
           channel: stable
 
       - name: Configure Flutter
-        run: |
-          flutter config --no-analytics
-          flutter config --enable-macos-desktop
+        run: flutter config --no-analytics
 
       - name: Fetch Dart dependencies
         run: flutter pub get
@@ -154,9 +148,7 @@ jobs:
           channel: stable
 
       - name: Configure Flutter
-        run: |
-          flutter config --no-analytics
-          flutter config --enable-ios
+        run: flutter config --no-analytics
 
       - name: Fetch Dart dependencies
         run: flutter pub get
@@ -164,7 +156,7 @@ jobs:
       - name: Install CocoaPods dependencies
         run: |
           cd ios
-          pod install
+          pod install --repo-update
 
       - name: Build iOS (release, no codesign)
         run: flutter build ios --release --no-codesign
@@ -194,18 +186,13 @@ jobs:
           flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: stable
 
-      - name: Configure Flutter target
-        shell: pwsh
-        run: |
-          flutter config --no-analytics
-          flutter config --enable-windows-desktop
+      - name: Configure Flutter
+        run: flutter config --no-analytics
 
       - name: Fetch Dart dependencies
-        shell: pwsh
         run: flutter pub get
 
       - name: Build Windows desktop (release)
-        shell: pwsh
         run: flutter build windows --release
 
       - name: Upload Windows artifact

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -11,8 +11,13 @@ plugins {
 
 val keystoreProperties = Properties()
 val keystorePropertiesFile = rootProject.file("key.properties")
-if (keystorePropertiesFile.exists()) {
+val hasKeystore = if (keystorePropertiesFile.exists()) {
     keystoreProperties.load(FileInputStream(keystorePropertiesFile))
+    listOf("keyAlias", "keyPassword", "storeFile", "storePassword").all {
+        keystoreProperties.getProperty(it)?.isNotBlank() == true
+    }
+} else {
+    false
 }
 
 android {
@@ -30,10 +35,14 @@ android {
 
     signingConfigs {
         create("release") {
-            keyAlias = keystoreProperties["keyAlias"] as String
-            keyPassword = keystoreProperties["keyPassword"] as String
-            storeFile = keystoreProperties["storeFile"]?.let { file(it) }
-            storePassword = keystoreProperties["storePassword"] as String
+            if (hasKeystore) {
+                keyAlias = keystoreProperties.getProperty("keyAlias")
+                keyPassword = keystoreProperties.getProperty("keyPassword")
+                storeFile = keystoreProperties.getProperty("storeFile")?.let { file(it) }
+                storePassword = keystoreProperties.getProperty("storePassword")
+            } else {
+                initWith(getByName("debug"))
+            }
         }
     }
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -40,9 +40,8 @@ android {
                 keyPassword = keystoreProperties.getProperty("keyPassword")
                 storeFile = keystoreProperties.getProperty("storeFile")?.let { file(it) }
                 storePassword = keystoreProperties.getProperty("storePassword")
-            } else {
-                initWith(getByName("debug"))
             }
+            // If no keystore is provided, the debug signing config will be used automatically
         }
     }
 
@@ -59,9 +58,12 @@ android {
 
     buildTypes {
         release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now, so `flutter run --release` works.
-            signingConfig = signingConfigs.getByName("release")
+            // Use release signing config if keystore is provided, otherwise use debug
+            signingConfig = if (hasKeystore) {
+                signingConfigs.getByName("release")
+            } else {
+                signingConfigs.getByName("debug")
+            }
         }
     }
 }

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,0 +1,51 @@
+# Uncomment this line to define a global platform for your project
+platform :ios, '13.0'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_ios_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+  use_modular_headers!
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+
+  target 'RunnerTests' do
+    inherit! :search_paths
+  end
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+    
+    target.build_configurations.each do |config|
+      # You can enable the Swift version if needed
+      config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '13.0'
+      config.build_settings['ENABLE_BITCODE'] = 'NO'
+    end
+  end
+end


### PR DESCRIPTION
允许在未签名的情况下通过**手动启动** github action 来构建各个平台的安装包, 并自动在Release创建**草稿**，须**手动确认**草稿才能发布

效果

[https://github.com/xingwangzhe/RustAssistantRebuild/actions/runs/18181709272](https://github.com/xingwangzhe/RustAssistantRebuild/actions/runs/18181709272)

[https://github.com/xingwangzhe/RustAssistantRebuild/releases/tag/v1.0.1](https://github.com/xingwangzhe/RustAssistantRebuild/releases/tag/v1.0.1)